### PR TITLE
Predefined beraters

### DIFF
--- a/lib/berater.rb
+++ b/lib/berater.rb
@@ -1,4 +1,5 @@
 require 'berater/limiter'
+require 'berater/limiter_set'
 require 'berater/lock'
 require 'berater/lua_script'
 require 'berater/utils'
@@ -16,9 +17,8 @@ module Berater
     yield self
   end
 
-  def reset
-    @redis = nil
-    middleware.clear
+  def limiters
+    @limiters ||= LimiterSet.new
   end
 
   def middleware(&block)
@@ -56,6 +56,11 @@ module Berater
     end
   end
 
+  def reset
+    @redis = nil
+    limiters.clear
+    middleware.clear
+  end
 end
 
 # convenience method

--- a/lib/berater/limiter_set.rb
+++ b/lib/berater/limiter_set.rb
@@ -1,0 +1,66 @@
+module Berater
+  private
+
+  class LimiterSet
+    include Enumerable
+
+    def initialize
+      @limiters = {}
+    end
+
+    def each(&block)
+      @limiters.each_value(&block)
+    end
+
+    def <<(limiter)
+      key = limiter.key if limiter.respond_to?(:key)
+      send(:[]=, key, limiter)
+    end
+
+    def []=(key, limiter)
+      unless limiter.is_a? Berater::Limiter
+        raise ArgumentError, "expected Berater::Limiter, found: #{limiter}"
+      end
+
+      @limiters[key] = limiter
+    end
+
+    def [](key)
+      @limiters[key]
+    end
+
+    def fetch(key, val = default = true, &block)
+      args = default ? [ key ] : [ key, val ]
+      @limiters.fetch(*args, &block)
+    end
+
+    def include?(key)
+      if key.is_a? Berater::Limiter
+        @limiters.value?(key)
+      else
+        @limiters.key?(key)
+      end
+    end
+
+    def clear
+      @limiters.clear
+    end
+
+    def count
+      @limiters.count
+    end
+
+    def delete(key)
+      if key.is_a? Berater::Limiter
+        @limiters.delete(key.key)
+      else
+        @limiters.delete(key)
+      end
+    end
+    alias remove delete
+
+    def empty?
+      @limiters.empty?
+    end
+  end
+end

--- a/spec/berater_spec.rb
+++ b/spec/berater_spec.rb
@@ -24,6 +24,24 @@ describe Berater do
     end
   end
 
+  describe '.limiters' do
+    subject { Berater.limiters }
+
+    let(:limiter) { Berater(:key, 1) }
+
+    it 'provides access to predefined limiters' do
+      expect(Berater.limiters).to be_a Berater::LimiterSet
+    end
+
+    it 'resets with Berater' do
+      subject << limiter
+      is_expected.not_to be_empty
+
+      Berater.reset
+      is_expected.to be_empty
+    end
+  end
+
   shared_examples 'a Berater' do |klass, capacity, **opts|
     describe '.new' do
       let(:limiter) { Berater.new(:key, capacity, **opts) }

--- a/spec/limiter_set_spec.rb
+++ b/spec/limiter_set_spec.rb
@@ -1,0 +1,173 @@
+describe Berater::LimiterSet do
+  subject { described_class.new }
+
+  let(:unlimiter) { Berater::Unlimiter.new }
+  let(:inhibitor) { Berater::Inhibitor.new }
+
+  describe '#each' do
+    it 'returns an Enumerator' do
+      expect(subject.each).to be_a Enumerator
+    end
+
+    it 'works with an empty set' do
+      expect(subject.each.to_a).to eq []
+    end
+
+    it 'returns elements' do
+      subject << unlimiter
+      expect(subject.each.to_a).to eq [ unlimiter ]
+    end
+  end
+
+  describe '#<<' do
+    it 'adds a limiter' do
+      subject << unlimiter
+      expect(subject.each.to_a).to eq [ unlimiter ]
+    end
+
+    it 'rejects things that are not limiters' do
+      expect {
+        subject << :foo
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'updates existing keys' do
+      limiter = Berater::Unlimiter.new
+      expect(limiter).to eq unlimiter
+      expect(limiter).not_to be unlimiter
+
+      subject << unlimiter
+      subject << limiter
+
+      expect(subject.each.to_a).to eq [ limiter ]
+    end
+  end
+
+  describe '[]=' do
+    it 'adds a limiter' do
+      subject[:key] = unlimiter
+
+      expect(subject.each.to_a).to eq [ unlimiter ]
+      is_expected.to include :key
+      is_expected.to include unlimiter
+    end
+
+    it 'rejects things that are not limiters' do
+      expect {
+        subject[:key] = :foo
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#[]' do
+    it 'returns nil for missing keys' do
+      expect(subject[:key]).to be nil
+      expect(subject[nil]).to be nil
+    end
+
+    it 'retreives limiters' do
+      subject << unlimiter
+      expect(subject[unlimiter.key]).to be unlimiter
+    end
+  end
+
+  describe '#fetch' do
+    it 'raises for missing keys' do
+      expect {
+        subject.fetch(:key)
+      }.to raise_error(KeyError)
+
+      expect {
+        subject.fetch(nil)
+      }.to raise_error(KeyError)
+    end
+
+    it 'returns the default if provided' do
+      expect(subject.fetch(:key, unlimiter)).to be unlimiter
+    end
+
+    it 'calls the default proc if provided' do
+      expect {|block| subject.fetch(:key, &block) }.to yield_control
+    end
+
+    it 'retreives limiters' do
+      subject << unlimiter
+      expect(subject.fetch(unlimiter.key)).to be unlimiter
+      expect(subject.fetch(unlimiter.key, :default)).to be unlimiter
+    end
+  end
+
+  describe '#include?' do
+    before do
+      subject << unlimiter
+    end
+
+    it 'works with keys' do
+      is_expected.to include unlimiter.key
+    end
+
+    it 'works with limiters' do
+      is_expected.to include unlimiter
+    end
+
+    it 'works when target is missing' do
+      is_expected.not_to include inhibitor.key
+      is_expected.not_to include inhibitor
+    end
+  end
+
+  describe '#clear' do
+    it 'works when empty' do
+      subject.clear
+    end
+
+    it 'clears limiters' do
+      subject << unlimiter
+      is_expected.to include unlimiter
+
+      subject.clear
+      is_expected.not_to include unlimiter
+    end
+  end
+
+  describe '#count' do
+    it 'counts' do
+      expect(subject.count).to be 0
+
+      subject << unlimiter
+      expect(subject.count).to be 1
+    end
+  end
+
+  describe '#delete' do
+    it 'works when the target is missing' do
+      subject.delete(unlimiter)
+      subject.delete(unlimiter.key)
+    end
+
+    it 'works with keys' do
+      subject << unlimiter
+      is_expected.to include unlimiter
+
+      subject.delete(unlimiter.key)
+      is_expected.not_to include unlimiter
+    end
+
+    it 'works with limiters' do
+      subject << unlimiter
+      is_expected.to include unlimiter
+
+      subject.delete(unlimiter)
+      is_expected.not_to include unlimiter
+    end
+  end
+
+  describe '#empty?' do
+    it 'works' do
+      is_expected.to be_empty
+
+      subject << unlimiter
+      is_expected.not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
make it possible to register limiters up front for reuse later

eg.
```ruby
# config/initializers/berater.rb
Berater.config do |config|
  config.limiters << Berater::RateLimiter.new(:key, 1, :second)
end

# or
Berater.limiters << Berater::RateLimiter.new(:key, 1, :second)


# app/...
Berater.limiters[:key].limit { ... }

# or 
Berater.limiters[:key] ||= Berater::Unlimiter.new
Berater.limiters[:key].limit { ... }
```