### PR TITLE
ruby 3 compatbilitiy

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,7 +3,7 @@
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
   pull_request:
@@ -13,15 +13,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ruby-version: [ 3.0, 2.7, 2.5 ]
+
+    name: Ruby ${{ matrix.ruby-version }}
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.5.5
-        bundler-cache: true
-    - run: bundle install
-    - name: start Redis
-      uses: supercharge/redis-github-action@1.2.0
-      with:
-        redis-version: 6.0
-    - run: bundle exec rake test
+      - uses: actions/checkout@v2
+      - name: start Redis
+        run: docker run --name redis --publish 6379:6379 --detach redis:latest
+      - name: setup Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: install dependencies
+        run: bundle install
+      - name: run tests
+        run: bundle exec rake test

--- a/berater.gemspec
+++ b/berater.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files       = Dir.glob('lib/**/*')
   s.test_files  = Dir.glob('spec/**/*_spec.rb')
 
-  s.add_runtime_dependency 'meddleware'
-  s.add_runtime_dependency 'redis'
+  s.add_runtime_dependency 'meddleware', '>= 0.2'
+  s.add_runtime_dependency 'redis', '>= 3'
 
   s.add_development_dependency 'benchmark'
   s.add_development_dependency 'byebug'

--- a/lib/berater/limiter.rb
+++ b/lib/berater/limiter.rb
@@ -99,7 +99,7 @@ module Berater
     end
 
     class << self
-      def new(*)
+      def new(*args, **kwargs)
         # can only call via subclass
         raise NoMethodError if self == Berater::Limiter
 
@@ -116,6 +116,7 @@ module Berater
       def inherited(subclass)
         # automagically create convenience method
         name = subclass.to_s.split(':')[-1]
+
         Berater.define_singleton_method(name) do |*args, **opts, &block|
           Berater::Utils.convenience_fn(subclass, *args, **opts, &block)
         end

--- a/lib/berater/utils.rb
+++ b/lib/berater/utils.rb
@@ -44,12 +44,7 @@ module Berater
 
     def convenience_fn(klass, *args, **opts, &block)
       limiter = klass.new(*args, **opts)
-      if block_given?
-        limiter.limit(&block)
-      else
-        limiter
-      end
+      block ? limiter.limit(&block) : limiter
     end
-
   end
 end

--- a/spec/berater_spec.rb
+++ b/spec/berater_spec.rb
@@ -60,7 +60,7 @@ describe Berater do
 
       it 'accepts an optional redis parameter' do
         redis = double(Redis)
-        limiter = Berater.new(:key, capacity, opts.merge(redis: redis))
+        limiter = Berater.new(:key, capacity, **opts.merge(redis: redis))
         expect(limiter.redis).to be redis
       end
     end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,5 +1,5 @@
 class Meddler
-  def call(*)
+  def call(*args, **kwargs)
     yield
   end
 end
@@ -73,18 +73,18 @@ describe 'Berater.middleware' do
 
     context 'when middleware meddles' do
       it 'can change the capacity' do
-        expect(middleware).to receive(:call) do |limiter, opts, &block|
+        expect(middleware).to receive(:call) do |limiter, **opts, &block|
           opts[:capacity] = 0
-          block.call
+          block.call(limiter, **opts)
         end
 
         expect { limiter.limit }.to be_overloaded
       end
 
       it 'can change the cost' do
-        expect(middleware).to receive(:call) do |limiter, opts, &block|
+        expect(middleware).to receive(:call) do |limiter, **opts, &block|
           opts[:cost] = 2
-          block.call
+          block.call(limiter, **opts)
         end
 
         expect { limiter.limit }.to be_overloaded
@@ -93,8 +93,8 @@ describe 'Berater.middleware' do
       it 'can change the limiter' do
         other_limiter = Berater::Inhibitor.new
 
-        expect(middleware).to receive(:call) do |limiter, opts, &block|
-          block.call other_limiter, opts
+        expect(middleware).to receive(:call) do |limiter, **opts, &block|
+          block.call(other_limiter, **opts)
         end
         expect(other_limiter).to receive(:acquire_lock).and_call_original
 

--- a/spec/support/limiter_examples.rb
+++ b/spec/support/limiter_examples.rb
@@ -84,7 +84,9 @@ RSpec.shared_examples 'a limiter' do |limiter|
   end
 
   describe 'convenience method' do
-    subject { Berater.send(method_name, *params) }
+    subject do
+      Berater.send(method_name, *params, **limiter.options)
+    end
 
     let(:method_name) { limiter.class.name.split(':')[-1] }
     let(:params) {
@@ -92,8 +94,7 @@ RSpec.shared_examples 'a limiter' do |limiter|
         limiter.key,
         limiter.capacity,
         *limiter.send(:args),
-        **limiter.options,
-      ].compact
+      ]
     }
 
     it 'exists' do


### PR DESCRIPTION
upgrade Berater to be compatible with Ruby 2.5 / 2.7 / 3.0 and add CI test coverage

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0

https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html