### PR TITLE
Acquire lock opts

### DIFF
--- a/lib/berater/concurrency_limiter.rb
+++ b/lib/berater/concurrency_limiter.rb
@@ -63,7 +63,7 @@ module Berater
     LUA
     )
 
-    protected def acquire_lock(capacity, cost)
+    protected def acquire_lock(capacity:, cost:)
       # round fractional capacity and cost
       capacity = capacity.to_i
       cost = cost.ceil

--- a/lib/berater/limiter.rb
+++ b/lib/berater/limiter.rb
@@ -114,9 +114,8 @@ module Berater
       raise NotImplementedError
     end
 
-    def cache_key(subkey = nil)
-      instance_key = subkey.nil? ? key : "#{key}:#{subkey}"
-      self.class.cache_key(instance_key)
+    def cache_key
+      self.class.cache_key(key)
     end
 
     class << self

--- a/lib/berater/limiter.rb
+++ b/lib/berater/limiter.rb
@@ -1,5 +1,6 @@
 module Berater
   class Limiter
+    DEFAULT_COST = 1
 
     attr_reader :key, :capacity, :options
 
@@ -9,7 +10,7 @@ module Berater
 
     def limit(**opts, &block)
       opts[:capacity] ||= @capacity
-      opts[:cost] ||= 1
+      opts[:cost] ||= DEFAULT_COST
 
       lock = Berater.middleware.call(self, **opts) do |limiter, **opts|
         limiter.inner_limit(**opts)
@@ -26,7 +27,7 @@ module Berater
       end
     end
 
-    protected def inner_limit(capacity:, cost:)
+    protected def inner_limit(capacity:, cost:, **opts)
       if capacity.is_a?(String)
         # try casting
         begin
@@ -49,7 +50,7 @@ module Berater
         raise ArgumentError, "invalid cost: #{cost}"
       end
 
-      acquire_lock(capacity, cost)
+      acquire_lock(capacity: capacity, cost: cost, **opts)
     rescue NoMethodError => e
       raise unless e.message.include?("undefined method `evalsha' for")
 
@@ -110,7 +111,7 @@ module Berater
       @capacity = capacity
     end
 
-    def acquire_lock(capacity, cost)
+    def acquire_lock(capacity:, cost:)
       raise NotImplementedError
     end
 

--- a/lib/berater/rate_limiter.rb
+++ b/lib/berater/rate_limiter.rb
@@ -71,7 +71,7 @@ module Berater
     LUA
     )
 
-    protected def acquire_lock(capacity, cost)
+    protected def acquire_lock(capacity:, cost:)
       # timestamp in milliseconds
       ts = (Time.now.to_f * 10**3).to_i
 

--- a/lib/berater/static_limiter.rb
+++ b/lib/berater/static_limiter.rb
@@ -18,7 +18,7 @@ module Berater
     LUA
     )
 
-    protected def acquire_lock(capacity, cost)
+    protected def acquire_lock(capacity:, cost:)
       if cost == 0
         # utilization check
         count = redis.get(cache_key) || "0"

--- a/lib/berater/test_mode.rb
+++ b/lib/berater/test_mode.rb
@@ -21,7 +21,7 @@ module Berater
 
   class Limiter
     module TestMode
-      def acquire_lock(*)
+      def acquire_lock(**)
         case Berater.test_mode
         when :pass
           Lock.new(Float::INFINITY, 0)

--- a/spec/limiter_spec.rb
+++ b/spec/limiter_spec.rb
@@ -47,7 +47,9 @@ describe Berater::Limiter do
 
     context 'with a capacity parameter' do
       it 'overrides the stored value' do
-        is_expected.to receive(:acquire_lock).with(3, anything)
+        is_expected.to receive(:acquire_lock).with(hash_including(
+          capacity: 3,
+        ))
 
         subject.limit(capacity: 3)
       end
@@ -59,15 +61,29 @@ describe Berater::Limiter do
       end
 
       it 'handles stringified numerics gracefully' do
-        is_expected.to receive(:acquire_lock).with(3.5, anything)
+        is_expected.to receive(:acquire_lock).with(hash_including(
+          capacity: 3.5,
+        ))
 
         subject.limit(capacity: '3.5')
       end
     end
 
+    it 'has a default cost' do
+      is_expected.to receive(:acquire_lock).with(hash_including(
+        cost: described_class::DEFAULT_COST,
+      ))
+
+      subject.limit
+    end
+
     context 'with a cost parameter' do
-      it 'overrides the stored value' do
-        is_expected.to receive(:acquire_lock).with(anything, 2)
+      it 'overrides the default value' do
+        expect(described_class::DEFAULT_COST).not_to eq 2
+
+        is_expected.to receive(:acquire_lock).with(hash_including(
+          cost: 2,
+        ))
 
         subject.limit(cost: 2)
       end
@@ -87,10 +103,21 @@ describe Berater::Limiter do
       end
 
       it 'handles stringified numerics gracefully' do
-        is_expected.to receive(:acquire_lock).with(anything, 2.5)
+        is_expected.to receive(:acquire_lock).with(hash_including(
+          cost: 2.5,
+        ))
 
         subject.limit(cost: '2.5')
       end
+    end
+
+    it 'passes through arbitrary parameters' do
+      is_expected.to receive(:acquire_lock).with(hash_including(
+        priority: 123,
+        zed: nil,
+      ))
+
+      subject.limit(priority: 123, zed: nil)
     end
 
     context 'when Berater.redis is nil' do


### PR DESCRIPTION
make it possible to pass arbitrary options into `.limit` and have them passed through to `.acquire_lock`