### PR TITLE
Attach lock context to overloaded exceptions for better metrics

### DIFF
--- a/lib/berater.rb
+++ b/lib/berater.rb
@@ -12,7 +12,14 @@ module Berater
   include Meddleware
   extend self
 
-  class Overloaded < StandardError; end
+  class Overloaded < StandardError
+    attr_reader :lock
+
+    def initialize(lock = nil)
+      @lock = lock
+      super()
+    end
+  end
 
   attr_accessor :redis
 

--- a/lib/berater/concurrency_limiter.rb
+++ b/lib/berater/concurrency_limiter.rb
@@ -77,7 +77,7 @@ module Berater
         [ capacity, ts, @timeout, cost ]
       )
 
-      raise Overloaded if lock_ids.empty?
+      raise Overloaded.new(Lock.new(capacity, count)) if lock_ids.empty?
 
       release_fn = if cost > 0
         proc { redis.zrem(cache_key, lock_ids) }

--- a/lib/berater/inhibitor.rb
+++ b/lib/berater/inhibitor.rb
@@ -10,7 +10,7 @@ module Berater
     end
 
     protected def acquire_lock(*)
-      raise Overloaded
+      raise Overloaded.new(Lock.new(capacity, capacity))
     end
 
   end

--- a/lib/berater/middleware/statsd.rb
+++ b/lib/berater/middleware/statsd.rb
@@ -13,6 +13,10 @@ module Berater
         # capture exception for reporting, then propagate
         raise
       ensure
+        if !lock && error.is_a?(Berater::Overloaded)
+          lock = error.lock
+        end
+
         duration += Process.clock_gettime(Process::CLOCK_MONOTONIC)
         duration = (duration * 1_000).round(2) # milliseconds
 

--- a/lib/berater/middleware/trace.rb
+++ b/lib/berater/middleware/trace.rb
@@ -15,6 +15,10 @@ module Berater
             # capture exception for reporting, then propagate
             raise
           ensure
+            if !lock && error.is_a?(Berater::Overloaded)
+              lock = error.lock
+            end
+
             span.set_tag('capacity', limiter.capacity)
             span.set_tag('contention', lock.contention) if lock
             span.set_tag('key', limiter.key)

--- a/lib/berater/rate_limiter.rb
+++ b/lib/berater/rate_limiter.rb
@@ -82,7 +82,7 @@ module Berater
 
       count = count.include?('.') ? count.to_f : count.to_i
 
-      raise Overloaded unless allowed
+      raise Overloaded.new(Lock.new(capacity, count)) unless allowed
 
       Lock.new(capacity, count)
     end
@@ -103,4 +103,3 @@ module Berater
 
   end
 end
-

--- a/lib/berater/static_limiter.rb
+++ b/lib/berater/static_limiter.rb
@@ -32,7 +32,7 @@ module Berater
       # Redis returns Floats as strings to maintain precision
       count = count.include?('.') ? count.to_f : count.to_i
 
-      raise Overloaded unless allowed
+      raise Overloaded.new(Lock.new(capacity, count)) unless allowed
 
       release_fn = if cost > 0
         proc { redis.incrbyfloat(cache_key, -cost) }

--- a/spec/middleware/statsd_spec.rb
+++ b/spec/middleware/statsd_spec.rb
@@ -243,10 +243,16 @@ describe Berater::Middleware::Statsd do
         )
       end
 
-      it 'does not track lock-based stats' do
-        expect(client).not_to receive(:gauge).with(
-          /berater.lock/,
-          any_args,
+      it 'tracks lock-based stats from the overloaded error lock' do
+        expect(client).to receive(:gauge).with(
+          'berater.lock.capacity',
+          limiter.capacity,
+          Hash,
+        )
+        expect(client).to receive(:gauge).with(
+          'berater.lock.contention',
+          limiter.capacity,
+          Hash,
         )
       end
 

--- a/spec/middleware/trace_spec.rb
+++ b/spec/middleware/trace_spec.rb
@@ -96,6 +96,7 @@ describe Berater::Middleware::Trace do
 
       it 'tags the span as overloaded and raises' do
         expect(span).to receive(:set_tag).with('overloaded', true)
+        expect(span).to receive(:set_tag).with('contention', 0)
 
         expect {
           limiter.limit


### PR DESCRIPTION
### Motivation
- Make it possible for middleware to report lock-based metrics (capacity/contention) even when a limiter raises an overloaded error by carrying lock context on the exception.
- Improve observability of overload events so StatsD and tracing middleware can record meaningful stats instead of only noting an error.

### Description
- Add `Berater::Overloaded#lock` and an initializer that accepts a `Lock` instance so overload exceptions can carry lock details.
- Update concrete limiters (`StaticLimiter`, `RateLimiter`, `ConcurrencyLimiter`, `Inhibitor`) to raise `Overloaded.new(Lock.new(...))` with the appropriate `capacity` and `count`/`contention` when the request is refused.
- Update `Statsd` middleware to use `error.lock` when no `lock` was returned so lock gauges are emitted for overload events.
- Update `Trace` middleware to retrieve lock info from `error.lock` when applicable so traces can still tag contention on overloads, and update specs to assert the new behavior.

### Testing
- Updated middleware specs `spec/middleware/statsd_spec.rb` and `spec/middleware/trace_spec.rb` to validate lock-based metrics/tags are captured from the overloaded exception's lock; these specs were modified alongside code changes.
- Attempted to run relevant specs with `bundle exec rspec spec/middleware/statsd_spec.rb spec/middleware/trace_spec.rb spec/concurrency_limiter_spec.rb spec/rate_limiter_spec.rb spec/static_limiter_spec.rb spec/inhibitor_spec.rb` but the environment cannot run them here: `bundler: command not found: rspec`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9eeb3a308321adeab0355f79de2d)