### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/berater.gemspec
+++ b/berater.gemspec
@@ -1,16 +1,12 @@
-package_name = Dir.glob('*.gemspec')[0].split('.')[0]
-require "./lib/#{package_name}/version"
-
-package = Berater
-
+require_relative 'lib/berater/version'
 
 Gem::Specification.new do |s|
-  s.name        = package_name
-  s.version     = package.const_get 'VERSION'
+  s.name        = 'berater'
+  s.version     = Berater::VERSION
   s.authors     = ['Daniel Pepper']
-  s.summary     = package.to_s
+  s.summary     = 'Berater'
   s.description = 'work...within limits'
-  s.homepage    = "https://github.com/dpep/#{package_name}_rb"
+  s.homepage    = 'https://github.com/dpep/berater_rb'
   s.license     = 'MIT'
   s.files       = `git ls-files * ':!:spec'`.split("\n")
 


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "berater"
s.version = Berater::VERSION
```


## Test plan

- [x] `Bundler.load_gemspec("berater.gemspec")` parses statically to name=`berater`, version=`0.15.1`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
