### PR TITLE
Bring repo up to speed

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: start Redis
-        run: docker run --name redis --publish 6379:6379 --detach redis:3
+        run: docker run --name redis --publish 6379:6379 --detach redis:7
       - name: clone ${{ github.repository }}
         uses: actions/checkout@v6
       - name: setup Ruby ${{ matrix.ruby-version }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,17 +19,16 @@ GEM
       logger
       msgpack
     datadog-ruby_core_source (3.5.2)
-    date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
     dogstatsd-ruby (5.7.1)
-    erb (6.0.2)
+    erb (6.0.4)
     ffi (1.17.4)
     io-console (0.8.2)
-    irb (1.17.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
@@ -40,20 +39,22 @@ GEM
     logger (1.7.0)
     meddleware (0.4.0)
     msgpack (1.8.3)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.3.1)
-      date
-      stringio
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.28.0)
+    redis-client (0.30.0)
       connection_pool
     reline (0.6.3)
       io-console (~> 0.5)
@@ -76,7 +77,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    stringio (3.2.0)
     timecop (0.9.11)
     tsort (0.2.0)
 


### PR DESCRIPTION
Routine maintenance to bring the repo up to speed.

- `bundle update` — bump transitive deps in `Gemfile.lock` (redis-client 0.28→0.30, irb, rdoc, pp, add rbs)
- CI: test against `redis:7` instead of EOL `redis:3` — validated locally against Redis 7.2.6

Tests: 634 examples, 0 failures.

🤖 vibed with [Claude Code](https://claude.com/claude-code)
