### PR TITLE
Heartbeats for faster lock reclamation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+###  unreleased
+- heartbeats - concurrency locks use short, renewable leases so failed processes are reclaimed quickly.  timeout remains the max hold time
+
 ###  v0.15.1  (2024-02-06)
 - fail open errors
 - simplify

--- a/lib/berater.rb
+++ b/lib/berater.rb
@@ -1,3 +1,4 @@
+require 'berater/heartbeat'
 require 'berater/limiter'
 require 'berater/limiter_set'
 require 'berater/lock'
@@ -14,7 +15,13 @@ module Berater
 
   class Overloaded < StandardError; end
 
+  DEFAULT_HEARTBEAT_INTERVAL = 5 # seconds
+
   attr_accessor :redis
+
+  # how often to renew leases on held locks.  nil disables heartbeats
+  attr_accessor :heartbeat_interval
+  @heartbeat_interval = DEFAULT_HEARTBEAT_INTERVAL
 
   def configure
     yield self
@@ -55,8 +62,10 @@ module Berater
 
   def reset
     @redis = nil
+    @heartbeat_interval = DEFAULT_HEARTBEAT_INTERVAL
     limiters.clear
     middleware.clear
+    Heartbeat.reset
   end
 end
 

--- a/lib/berater/concurrency_limiter.rb
+++ b/lib/berater/concurrency_limiter.rb
@@ -71,16 +71,35 @@ module Berater
       # timestamp in milliseconds
       ts = (Time.now.to_f * 10**3).to_i
 
+      # heartbeats permit a shorter lease, so locks from failed
+      # processes are reclaimed quickly.  timeout is still the max hold
+      lease_ttl = Heartbeat.lease_ttl
+      heartbeat = !lease_ttl.nil? && @timeout > lease_ttl
+      ttl = heartbeat ? lease_ttl : @timeout
+
       count, *lock_ids = LUA_SCRIPT.eval(
         redis,
         [ cache_key, self.class.cache_key('lock_id') ],
-        [ capacity, ts, @timeout, cost ]
+        [ capacity, ts, ttl, cost ]
       )
 
       raise Overloaded if lock_ids.empty?
 
+      entry = if heartbeat && cost > 0
+        Heartbeat.register(
+          redis:,
+          cache_key:,
+          lock_ids:,
+          acquired_at: ts,
+          timeout: @timeout,
+        )
+      end
+
       release_fn = if cost > 0
-        proc { redis.zrem(cache_key, lock_ids) }
+        proc do
+          Heartbeat.deregister(entry) if entry
+          redis.zrem(cache_key, lock_ids)
+        end
       end
 
       Lock.new(capacity, count, release_fn)

--- a/lib/berater/heartbeat.rb
+++ b/lib/berater/heartbeat.rb
@@ -1,0 +1,130 @@
+require 'berater/utils'
+
+module Berater
+  class Heartbeat
+
+    LEASE_FACTOR = 2
+
+    # wiggle room for transit and execution time
+    LEASE_GRACE_MS = 1_000
+
+    Entry = Struct.new(:redis, :cache_key, :lock_ids, :acquired_at, :timeout)
+
+    class << self
+      def interval_msec
+        interval = Berater.heartbeat_interval
+        return unless interval
+
+        msec = Berater::Utils.to_msec(interval)
+        msec if msec > 0
+      end
+
+      def lease_ttl
+        msec = interval_msec
+        msec && msec * LEASE_FACTOR + LEASE_GRACE_MS
+      end
+
+      def instance
+        @instance ||= new
+      end
+
+      def register(...)
+        instance.register(...)
+      end
+
+      def deregister(...)
+        instance.deregister(...)
+      end
+
+      def reset
+        @instance&.reset
+      end
+    end
+
+    def initialize
+      @entries = {}
+      @mutex = ::Mutex.new
+      @pid = Process.pid
+    end
+
+    def register(redis:, cache_key:, lock_ids:, acquired_at:, timeout:)
+      entry = Entry.new(redis, cache_key, lock_ids, acquired_at, timeout)
+
+      @mutex.synchronize do
+        prune_after_fork
+        @entries[entry] = true
+        start_thread
+      end
+
+      entry
+    end
+
+    def deregister(entry)
+      @mutex.synchronize { @entries.delete(entry) }
+    end
+
+    # renew leases for all registered locks
+    def beat
+      now = (Time.now.to_f * 10**3).to_i
+      ttl = self.class.lease_ttl
+
+      entries = @mutex.synchronize { @entries.keys }
+
+      entries.group_by { |e| [ e.redis, e.cache_key ] }.each do |(redis, cache_key), group|
+        # stop renewing locks which reached their max hold time
+        expired, live = group.partition { |e| (now - e.acquired_at) >= e.timeout }
+        expired.each { |e| deregister(e) }
+
+        next if ttl.nil? || live.empty?
+
+        scores = live.flat_map do |e|
+          # cap the lease so timeout remains the max hold time
+          score = [ now, e.acquired_at + e.timeout - ttl ].min
+          e.lock_ids.map { |id| [ score, id ] }
+        end
+
+        begin
+          redis.pipelined do |pipeline|
+            # renew held locks, without resurrecting reclaimed ones
+            pipeline.zadd(cache_key, scores, xx: true)
+            pipeline.pexpire(cache_key, ttl)
+          end
+        rescue StandardError
+          # eg. connection error.  locks may expire early, but
+          # the next beat will try again
+        end
+      end
+    end
+
+    def reset
+      @mutex.synchronize { @entries.clear }
+    end
+
+    private
+
+    def start_thread
+      return if @thread&.alive?
+
+      @thread = Thread.new do
+        Thread.current.name = 'berater-heartbeat'
+
+        loop do
+          msec = self.class.interval_msec
+          sleep(msec ? msec / 10**3.0 : 1)
+
+          beat rescue nil
+        end
+      end
+    end
+
+    def prune_after_fork
+      return if @pid == Process.pid
+
+      # child process inherits the registry, but locks belong to the parent
+      @pid = Process.pid
+      @entries.clear
+      @thread = nil
+    end
+
+  end
+end

--- a/spec/berater_spec.rb
+++ b/spec/berater_spec.rb
@@ -24,6 +24,23 @@ describe Berater do
     end
   end
 
+  describe '.heartbeat_interval' do
+    it 'has a default' do
+      expect(Berater.heartbeat_interval).to be Berater::DEFAULT_HEARTBEAT_INTERVAL
+    end
+
+    it 'can be updated' do
+      Berater.heartbeat_interval = 1
+      expect(Berater.heartbeat_interval).to be 1
+    end
+
+    it 'restores the default on reset' do
+      Berater.heartbeat_interval = nil
+      Berater.reset
+      expect(Berater.heartbeat_interval).to be Berater::DEFAULT_HEARTBEAT_INTERVAL
+    end
+  end
+
   describe '.limiters' do
     subject { Berater.limiters }
 

--- a/spec/concurrency_limiter_spec.rb
+++ b/spec/concurrency_limiter_spec.rb
@@ -117,18 +117,22 @@ describe Berater::ConcurrencyLimiter do
       expect(limiter).to be_overloaded
     end
 
-    it 'limit resets with millisecond precision' do
-      2.times { limiter.limit }
-      expect(limiter).to be_overloaded
+    context 'without heartbeats' do
+      before { Berater.heartbeat_interval = nil }
 
-      # travel forward to just before first lock times out
-      Timecop.freeze(29.999)
-      expect(limiter).to be_overloaded
+      it 'limit resets with millisecond precision' do
+        2.times { limiter.limit }
+        expect(limiter).to be_overloaded
 
-      # traveling one more millisecond will decrement the count
-      Timecop.freeze(0.001)
-      2.times { limiter.limit }
-      expect(limiter).to be_overloaded
+        # travel forward to just before first lock times out
+        Timecop.freeze(29.999)
+        expect(limiter).to be_overloaded
+
+        # traveling one more millisecond will decrement the count
+        Timecop.freeze(0.001)
+        2.times { limiter.limit }
+        expect(limiter).to be_overloaded
+      end
     end
 
     it 'accepts a dynamic capacity' do
@@ -253,6 +257,9 @@ describe Berater::ConcurrencyLimiter do
 
   describe '#utilization' do
     let(:limiter) { described_class.new(:key, 10, timeout: 30) }
+
+    # time jumps simulate locks going stale
+    before { Berater.heartbeat_interval = nil }
 
     it 'works' do
       expect(limiter.utilization).to eq 0

--- a/spec/heartbeat_spec.rb
+++ b/spec/heartbeat_spec.rb
@@ -1,0 +1,158 @@
+describe Berater::Heartbeat do
+  def entries(heartbeat = described_class.instance)
+    heartbeat.instance_variable_get(:@entries)
+  end
+
+  describe '.lease_ttl' do
+    def expect_lease_ttl(interval, expected)
+      Berater.heartbeat_interval = interval
+      expect(described_class.lease_ttl).to eq expected
+    end
+
+    it 'derives from the heartbeat interval, with wiggle room' do
+      expect_lease_ttl(5, 11_000)
+      expect_lease_ttl(1, 3_000)
+      expect_lease_ttl(0.5, 2_000)
+      expect_lease_ttl(:minute, 121_000)
+    end
+
+    it 'is disabled along with heartbeats' do
+      expect_lease_ttl(nil, nil)
+      expect_lease_ttl(0, nil)
+    end
+  end
+
+  context 'with a ConcurrencyLimiter' do
+    let(:limiter) { Berater::ConcurrencyLimiter.new(:key, 1, timeout: 30) }
+    let(:heartbeat) { described_class.instance }
+
+    it 'registers locks upon acquisition' do
+      lock = limiter.limit
+      expect(entries.size).to be 1
+
+      lock.release
+      expect(entries).to be_empty
+    end
+
+    it 'does not register locks with short timeouts' do
+      Berater::ConcurrencyLimiter.new(:key, 1, timeout: 1).limit
+      expect(entries).to be_empty
+    end
+
+    it 'does not register utilization checks' do
+      limiter.utilization
+      expect(entries).to be_empty
+    end
+
+    it 'does not register when heartbeats are disabled' do
+      Berater.heartbeat_interval = nil
+
+      limiter.limit
+      expect(entries).to be_empty
+    end
+
+    it 'reclaims locks from dead processes once the lease expires' do
+      limiter.limit
+      heartbeat.reset # simulate process death
+
+      expect(limiter).to be_overloaded
+
+      Timecop.freeze(12)
+      expect(limiter).not_to be_overloaded
+    end
+
+    it 'renews leases on held locks' do
+      limiter.limit
+
+      Timecop.freeze(6)
+      heartbeat.beat
+
+      # the original lease would have expired by now
+      Timecop.freeze(6)
+      expect(limiter).to be_overloaded
+
+      # once renewals stop, the lease expires
+      heartbeat.reset
+      Timecop.freeze(12)
+      expect(limiter).not_to be_overloaded
+    end
+
+    it 'respects timeout as the max hold time, with millisecond precision' do
+      limiter.limit
+
+      5.times do
+        Timecop.freeze(5)
+        heartbeat.beat
+      end
+
+      Timecop.freeze(4.999)
+      expect(limiter).to be_overloaded
+
+      Timecop.freeze(0.001)
+      expect(limiter).not_to be_overloaded
+    end
+
+    it 'stops renewing locks which reached their max hold time' do
+      limiter.limit
+
+      Timecop.freeze(31)
+      heartbeat.beat
+
+      expect(entries).to be_empty
+      expect(limiter).not_to be_overloaded
+    end
+
+    it 'does not resurrect released locks' do
+      lock = limiter.limit
+      entry = entries.keys.first
+      lock.release
+
+      heartbeat.register(**entry.to_h)
+      heartbeat.beat
+
+      expect(limiter).not_to be_overloaded
+    end
+
+    it 'tolerates redis errors, deferring to the next beat' do
+      limiter.limit
+      allow(Berater.redis).to receive(:pipelined).and_raise(Redis::ConnectionError)
+
+      expect { heartbeat.beat }.not_to raise_error
+    end
+  end
+
+  describe 'background thread' do
+    let(:heartbeat) { described_class.new }
+
+    def register(**opts)
+      heartbeat.register(
+        redis: Berater.redis,
+        cache_key: 'Berater:test:heartbeat',
+        lock_ids: [ 1 ],
+        acquired_at: (Time.now.to_f * 10**3).to_i,
+        timeout: 30_000,
+        **opts,
+      )
+    end
+
+    it 'starts upon registration and beats periodically' do
+      Berater.heartbeat_interval = 0.05
+      expect(heartbeat).to receive(:beat).at_least(:once)
+
+      register
+      expect(heartbeat.instance_variable_get(:@thread)).to be_alive
+
+      sleep 0.2
+    end
+
+    it 'prunes inherited entries after a fork' do
+      register
+      expect(entries(heartbeat).size).to be 1
+
+      allow(Process).to receive(:pid).and_return(0)
+
+      register(lock_ids: [ 2 ])
+      expect(entries(heartbeat).size).to be 1
+    end
+  end
+end


### PR DESCRIPTION
## What

`ConcurrencyLimiter` locks now use short, renewable leases. A background thread heartbeats every `Berater.heartbeat_interval` (default 5s), renewing leases on held locks. Locks from dead/failed processes stop being renewed and are reclaimed within one lease (`2 × interval + 1s` grace ≈ 11s by default) instead of the full `timeout`.

`timeout` remains the max hold time — renewal scores are capped at `acquired_at + timeout - lease`, so a lock expires at exactly `timeout` even with continuous heartbeats (millisecond precision preserved, see specs).

## Why

Previously `timeout` did double duty: lease TTL *and* worst-case work duration. Sizing it for the longest legitimate job meant crashed holders leaked their slot for that entire window. Heartbeats decouple the two: long jobs renew and stay safe, dead holders reclaim fast.

This also covers failed lock *releases*: a release whose `ZREM` fails is reclaimed within one lease rather than the full timeout.

## Design notes

- **Renewal is `ZADD XX`** (update-only) — it cannot resurrect a lock that was already purged and re-granted, so a slow/failed heartbeat degrades to "reclaimed early," never over-admission. Release (`ZREM` by unique lock id) stays idempotent.
- **Single shared Redis connection** — redis-rb 5.x synchronizes commands via a Monitor; the heartbeat is one pipelined round-trip per interval, batched across all held locks per (redis, key).
- **One thread per process**, lazily started on first registration; fork-safe (child prunes inherited entries).
- **Opt-out**: `Berater.heartbeat_interval = nil` restores classic fixed leases. Locks with `timeout <= lease` are unaffected (classic behavior).

## Deploy consideration

Mixed fleets sharing a key (heartbeat-enabled + older/disabled processes) will purge classic holders at the shorter lease — roll out together or disable heartbeats until fully deployed.

## Testing

- 651 examples, 0 failures; coverage 99.82%; stable across repeated random-order runs
- New specs cover: lease derivation, renewal, dead-process reclaim, exact max-hold precision, no-resurrection, Redis error tolerance, fork pruning, thread lifecycle

---
🤖 vibed with [Claude Code](https://claude.com/claude-code)
